### PR TITLE
Re-adding two new variables for announced_team/allow_approved.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,17 @@ This action automatically sends a message to google chats detailing the list of 
 
 **Required** PR labels to ignore when scanning for PR's. Defaults to `Stale`
 
+## `github-announced-team`
+
+**Optional** If provided PR's will be included from all members of that specific team.
+
 ## `github-announced-users`
 
 **Optional** Only Github users to announce PR's from. If set, other users' PR's will be ignored.
+
+## `github-allow-approved`
+
+**Optional** If provided then approved but unmerged PRs will also be included by the bot.
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,9 @@ runs:
     GITHUB_REPOSITORIES: ${{ inputs.github-repositories }}
     GITHUB_TOKEN: ${{ inputs.github-token }}
     GITHUB_IGNORED_USERS: ${{ inputs.github-ignored-users }}
+    GITHUB_ANNOUNCED_TEAM: ${{ inputs.github-announced-team }}
     GITHUB_ANNOUNCED_USERS: ${{ inputs.github-announced-users }}
     GITHUB_IGNORED_LABELS: ${{ inputs.github-ignored-labels }}
+    GITHUB_ALLOW_APPROVED: ${{ inputs.github-allow-approved }}
     GOOGLE_WEBHOOK_URL: ${{ inputs.google-webhook-url }}
     SHOW_PR_AGE: ${{ inputs.show-pr-age }}

--- a/src/github.rs
+++ b/src/github.rs
@@ -87,3 +87,27 @@ impl GithubPullRequest {
         ))
     }
 }
+
+impl GithubUser {
+    pub async fn list(team_id: &str, token: &str) -> Result<Vec<GithubUser>> {
+        let api_url = format!(
+            "https://api.github.com/orgs/guardian/teams/{}/members",
+            team_id
+        );
+
+        let response = reqwest::Client::new()
+            .get(&api_url)
+            .header("User-Agent", "GU-PR-Bot")
+            .bearer_auth(token)
+            .send()
+            .await?
+            .text()
+            .await
+            .context(format!("Failed to get response from: {}", &api_url))?;
+
+        serde_json::from_str(&response).context(format!(
+            "Failed to parse JSON when querying {}: {}",
+            &api_url, response
+        ))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use log::{info, Level};
 use std::env;
 
 use github::GithubPullRequest;
+use github::GithubUser;
 use google::GoogleChatMessage;
 
 const PUBLIC_REPO: &str = "public";
@@ -15,8 +16,10 @@ async fn scan_repository(
     repository_name: &str,
     github_token: &str,
     ignored_users: &[&str],
+    announced_team: &str,
     announced_users: &Option<Vec<usize>>,
     ignored_labels: &[&str],
+    allow_approved_prs: bool,
 ) -> Result<Vec<GithubPullRequest>, Error> {
     info!("\nStarting PR scan of {}", repository_name);
 
@@ -24,6 +27,22 @@ async fn scan_repository(
     let mut pull_requests_to_review: Vec<GithubPullRequest> = vec![];
 
     info!("Found {} PR's", pull_requests.len());
+
+    let user_list: Option<Vec<usize>> = if !announced_team.is_empty() {
+        info!("Getting team members for team {} ", announced_team);
+        match GithubUser::list(announced_team, github_token).await {
+            Ok(users) => Some(users.iter().map(|u| u.id).collect()),
+            Err(e) => {
+                if let Some(announced_users) = announced_users {
+                    Some(announced_users.clone())
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    } else {
+        announced_users.clone()
+    };
 
     for pull_request in pull_requests {
         let is_public = pull_request.head.repo.visibility == PUBLIC_REPO;
@@ -55,8 +74,8 @@ async fn scan_repository(
             continue;
         }
 
-        if let Some(announced_users) = announced_users {
-            if !announced_users.contains(&pull_request.user.id) {
+        if let Some(users) = &user_list {
+            if !users.contains(&pull_request.user.id) {
                 if is_public {
                     info!("Users to announce: {:?}", announced_users);
                     info!(
@@ -115,7 +134,7 @@ async fn scan_repository(
             }
         }
 
-        if !has_approved_reviews {
+        if !has_approved_reviews || allow_approved_prs {
             pull_requests_to_review.push(pull_request);
         }
     }
@@ -135,6 +154,7 @@ async fn main() -> Result<(), Error> {
         env::var("GOOGLE_WEBHOOK_URL").context("GOOGLE_WEBHOOK_URL must be set")?;
     let ignored_users: String = env::var("GITHUB_IGNORED_USERS").unwrap_or("".to_string());
     let ignored_users: Vec<&str> = ignored_users.split(',').collect();
+    let announced_team: String = env::var("GITHUB_ANNOUNCED_TEAM").unwrap_or("".to_string());
     let announced_users: Option<Vec<usize>> =
         env::var("GITHUB_ANNOUNCED_USERS").ok().and_then(|s| {
             if s.is_empty() {
@@ -148,6 +168,9 @@ async fn main() -> Result<(), Error> {
     let show_pr_age: bool = env::var("SHOW_PR_AGE")
         .map(|v| v == "true")
         .unwrap_or(false);
+    let allow_approved_prs: bool = env::var("GITHUB_ALLOW_APPROVED")
+        .map(|v| v == "true")
+        .unwrap_or(false);
 
     let mut pull_requests_to_review: Vec<GithubPullRequest> = vec![];
 
@@ -157,8 +180,10 @@ async fn main() -> Result<(), Error> {
                 repository,
                 &github_token,
                 &ignored_users,
+                &announced_team,
                 &announced_users,
                 &ignored_labels,
+                allow_approved_prs,
             )
             .await?,
         );


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We previously introduced two new variables that can be passed to the prnouncer bot in this earlier PR - https://github.com/guardian/actions-prnouncer/pull/48

However in doing so we introduced a bug. The issue was that the user_list provided was no longer an Option meaning that if announced_team was not provided it defaulted to an empty list. This mean that no Users were passed through to the bot when instead we want the opposite behaviour of all Users being passed through.

This PR switches user list to be an Option and return None. So that means that if user team or approved users not provided all PR's returned. 

The expected behaviour for the two new variables are as follows:

Announced team - optional flag to automatically get all user_ids in that team from GITHUB and return all user PRs. If not provided use annouced_users or default to all users.

Allow_approved - optional boolean flag to allow approved PR's to be surfaced. This is because we had a few PRs that were approved that were not merged and got closed instead.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Have tested locally in our own personal chat channel and have gotten success when running without announced_team passed through and all users in repo returned.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
